### PR TITLE
Update tags docs

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -13,7 +13,7 @@ Once the tag is removed from the instance, it will also be removed as a label on
 
 ## Taints
 
-In order for a tag to be synced to a taint, it needs to be of the form `taint=foo:bar:Effect`, where `Effect` is one of `NoExecute`, `NoSchedule` or `PreferNoSchedule`.
+In order for a tag to be synced to a taint, it needs to be of the form `taint=foo=bar:Effect`, where `Effect` is one of `NoExecute`, `NoSchedule` or `PreferNoSchedule`.
 In this case, the Kubernetes nodes will have the tain `k8s.scaleway.com/foo=bar` with the effect `Effect`.
 
 Once the tag is removed from the instance, it will also be removed as a taint on the node.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -7,14 +7,14 @@ The Scaleway CCM will also sync the tags of the Scaleway Instance to Kubernetes 
 ## Labels
 
 In order for a tag to be synced to a label, it needs to be of the form `foo=bar`.
-In this case, the Kuebrnetes nodes will have the label `k8s.scaleway.com/foo=bar`.
+In this case, the Kubernetes nodes will have the label `k8s.scaleway.com/foo=bar`.
 
 Once the tag is removed from the instance, it will also be removed as a label on the node.
 
 ## Taints
 
 In order for a tag to be synced to a taint, it needs to be of the form `taint=foo=bar:Effect`, where `Effect` is one of `NoExecute`, `NoSchedule` or `PreferNoSchedule`.
-In this case, the Kubernetes nodes will have the tain `k8s.scaleway.com/foo=bar` with the effect `Effect`.
+In this case, the Kubernetes nodes will have the taint `k8s.scaleway.com/foo=bar` with the effect `Effect`.
 
 Once the tag is removed from the instance, it will also be removed as a taint on the node.
 


### PR DESCRIPTION
I tried to use the tags on a pool to add a taint to all the nodes of that pool, as described in [`tags.md`](https://github.com/scaleway/scaleway-cloud-controller-manager/blob/master/docs/tags.md).

I added the tag `taint=foo:bar:NoExecute` to the pool. After waiting for a couple of minutes, the node in that pool received the taint `k8s.scaleway.com/foobar:NoExecute` instead of `k8s.scaleway.com/foo=bar:NoExecute`.

After reading [`sync_test.go`](https://github.com/scaleway/scaleway-cloud-controller-manager/blob/2c245787268486314eeb3f49c53e181bb05b3387/scaleway/sync_test.go#L34) I noticed that the expected syntax for the tags of pools is `taint=foo=bar:Effect`.

I tried it and it worked: my node has now the taint `k8s.scaleway.com/foo=bar:NoExecute`.

I fixed the docs according to this.

Also I fixed a typo...