### PR TITLE
feat(lb): Add timeout-client LB annotation

### DIFF
--- a/docs/loadbalancer-annotations.md
+++ b/docs/loadbalancer-annotations.md
@@ -95,6 +95,10 @@ The possible values are `false`, `true` or `*` for all ports or a comma delimite
 ### `service.beta.kubernetes.io/scw-loadbalancer-type`
 This is the annotation to set the load balancer offer type.
 
+### `service.beta.kubernetes.io/scw-loadbalancer-timeout-client`
+This is the annotation to set the maximum client connection inactivity time.
+The default value is `10m`. The duration are go's time.Duration (ex: `1s`, `2m`, `4h`, ...).
+
 ### `service.beta.kubernetes.io/scw-loadbalancer-timeout-server`
 This is the annotation to set the maximum server connection inactivity time.
 The default value is `10m`. The duration are go's time.Duration (ex: `1s`, `2m`, `4h`, ...).


### PR DESCRIPTION
This PR adds support for a new LB annotation `service.beta.kubernetes.io/scw-loadbalancer-timeout-client` that set the maximum idle time on frontend TCP connections.