### PR TITLE
feat: Add custom LB health check type using `healthCheckNodePort`

### DIFF
--- a/scaleway/loadbalancers.go
+++ b/scaleway/loadbalancers.go
@@ -1250,7 +1250,7 @@ func servicePortToBackend(service *v1.Service, loadbalancer *scwlb.LB, port v1.S
 		healthCheck.HTTPSConfig = &scwlb.HealthCheckHTTPConfig{
 			Method:     "GET",
 			Code:       scw.Int32Ptr(200),
-			URI:        "/",
+			URI:        "/healthz",
 		}
 	default:
 		klog.Errorf("wrong value for healthCheckType")


### PR DESCRIPTION
* Adds a **custom health check type** that instructs the CCM to:
  * Prefer `spec.HealthCheckNodePort` when available
  * Use it automatically without requiring explicit annotations
* Ensures safer behavior for `externalTrafficPolicy: Local` services

References:
- https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies
- https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-loadbalancer
- https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api/#externaltrafficpolicy-for-loadbalancer-or-nodeport-services

Closes #192