### PR TITLE
chore(ghactions): bump actions

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -9,27 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Extract branch name
         shell: bash
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
-      - name: Enable experimental on dockerd
-        run: |
-          echo $'{\n    "experimental": true\n}' | sudo tee /etc/docker/daemon.json
-          sudo service docker restart
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: latest
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
       - name: Make release
         run: make release
         env:
-          DOCKER_CLI_EXPERIMENTAL: enabled
           TAG: ${{ env.GITHUB_SHA }}
           IMAGE_TAG: ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,11 +13,9 @@ jobs:
     steps:
     # Checkout should always be before setup-go to ensure caching is working
     - name: checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
+      uses: actions/checkout@v6
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
     - name: Run unit tests
@@ -32,11 +30,9 @@ jobs:
     steps:
     # Checkout should always be before setup-go to ensure caching is working
     - name: checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
+      uses: actions/checkout@v6
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
     - name: Building binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,23 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Highest tag
         id: highestTag
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
           echo highest=$(git tag | grep -E "^v?([0-9]+\.)+[0-9]+$" | sort -r -V | head -n1) >> $GITHUB_OUTPUT
-      - name: Enable experimental on dockerd
-        run: |
-          echo $'{\n    "experimental": true\n}' | sudo tee /etc/docker/daemon.json
-          sudo service docker restart
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: latest
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
       - name: Get tag
@@ -33,13 +28,11 @@ jobs:
       - name: Make release
         run: make release
         env:
-          DOCKER_CLI_EXPERIMENTAL: enabled
           TAG: ${{ steps.tagName.outputs.tag }}
           IMAGE_TAG: ${{ steps.tagName.outputs.tag }}
       - name: Push latest
         if: steps.tagName.outputs.tag == steps.highestTag.outputs.highest
         run: make release
         env:
-          DOCKER_CLI_EXPERIMENTAL: enabled
           TAG: ${{ steps.tagName.outputs.tag }}
           IMAGE_TAG: latest


### PR DESCRIPTION
- Upgrade `actions/setup-go@v1` to `actions/setup-go@v6` (has the fix for https://github.com/actions/setup-go/issues/688)
- Upgrade `actions/checkout@v3` to `actions/checkout@v6`
- Change manual unshallow to use `actions/checkout` builtin
- Remove Docker experimental feature flag
- Setup QEMU before Buildx
- Upgrade `docker/setup-buildx-action@v2` to `docker/setup-buildx-action@v3`
