### PR TITLE
feat(loadbalancers): new selector style annotation to assoc LB with VPC/PN

### DIFF
--- a/docs/loadbalancer-annotations.md
+++ b/docs/loadbalancer-annotations.md
@@ -245,6 +245,43 @@ The possible formats are:
 - `<pn-id>`: will attach a single Private Network to the LB.
 - `<pn-id>,<pn-id>`: will attach the two Private Networks to the LB.
 
+### `service.beta.kubernetes.io/scw-loadbalancer-pn-names`
+
+This is the annotation to configure the Private Networks by name instead of ID.
+The private network names will be resolved to IDs at runtime. This is useful when
+you want to specify private networks without hardcoding their IDs, which can change
+when clusters are recreated.
+
+**Priority order:**
+1. `service.beta.kubernetes.io/scw-loadbalancer-pn-ids` (highest priority)
+2. `service.beta.kubernetes.io/scw-loadbalancer-pn-names`
+3. `PN_ID` environment variable (fallback)
+
+If both `pn-ids` and `pn-names` are set, `pn-ids` takes precedence and `pn-names` is ignored.
+This annotation is ignored when `service.beta.kubernetes.io/scw-loadbalancer-externally-managed` is enabled.
+
+The format must be `<vpc-name>/<pn-name>` to specify both the VPC and the private network name.
+Multiple entries can be comma-separated.
+
+**Examples:**
+```yaml
+# Single private network
+service.beta.kubernetes.io/scw-loadbalancer-pn-names: "default/my-private-network"
+
+# Multiple networks from different VPCs
+service.beta.kubernetes.io/scw-loadbalancer-pn-names: "prod-vpc/network-1,staging-vpc/network-2"
+
+# Multiple networks from the same VPC
+service.beta.kubernetes.io/scw-loadbalancer-pn-names: "default/network-1,default/network-2"
+```
+
+**Error handling:**
+- If the format is invalid (missing VPC or PN name), an error is returned.
+- If a private network name is not found, an error is returned.
+- If multiple private networks have the same name within the VPC, an error is returned.
+- If the specified VPC is not found, an error is returned.
+- If multiple VPCs have the same name, an error is returned.
+
 ### `service.beta.kubernetes.io/scw-loadbalancer-health-check-from-service`
 
 This is the annotation to configure the load balancer backend to use the service's `healthCheckNodePort` for health checks.

--- a/docs/loadbalancer-annotations.md
+++ b/docs/loadbalancer-annotations.md
@@ -247,14 +247,21 @@ The possible formats are:
 
 ### `service.beta.kubernetes.io/scw-loadbalancer-pn-names`
 
+> **Feature gate:** This annotation requires the `SCW_ENABLE_LB_PN_NAME_SELECTOR` environment variable
+> to be set to `"true"` on the cloud controller manager. When the environment variable is not set or set
+> to any other value, this annotation is ignored.
+
 This is the annotation to configure the Private Networks by name instead of ID.
 The private network names will be resolved to IDs at runtime. This is useful when
 you want to specify private networks without hardcoding their IDs, which can change
 when clusters are recreated.
 
+When enabled, IPAM-based node IP resolution is also activated, providing precise IP
+lookup for nodes connected to the configured private networks.
+
 **Priority order:**
 1. `service.beta.kubernetes.io/scw-loadbalancer-pn-ids` (highest priority)
-2. `service.beta.kubernetes.io/scw-loadbalancer-pn-names`
+2. `service.beta.kubernetes.io/scw-loadbalancer-pn-names` (requires `SCW_ENABLE_LB_PN_NAME_SELECTOR=true`)
 3. `PN_ID` environment variable (fallback)
 
 If both `pn-ids` and `pn-names` are set, `pn-ids` takes precedence and `pn-names` is ignored.

--- a/examples/k8s-scaleway-ccm-latest.yml
+++ b/examples/k8s-scaleway-ccm-latest.yml
@@ -32,7 +32,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: scaleway-cloud-controller-manager
-          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.6
+          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.11
           imagePullPolicy: Always
           args:
             - --cloud-provider=scaleway

--- a/examples/k8s-scaleway-ccm-latest.yml
+++ b/examples/k8s-scaleway-ccm-latest.yml
@@ -32,7 +32,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: scaleway-cloud-controller-manager
-          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.0
+          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.1
           imagePullPolicy: Always
           args:
             - --cloud-provider=scaleway

--- a/examples/k8s-scaleway-ccm-latest.yml
+++ b/examples/k8s-scaleway-ccm-latest.yml
@@ -32,7 +32,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: scaleway-cloud-controller-manager
-          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.3
+          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.4
           imagePullPolicy: Always
           args:
             - --cloud-provider=scaleway

--- a/examples/k8s-scaleway-ccm-latest.yml
+++ b/examples/k8s-scaleway-ccm-latest.yml
@@ -32,7 +32,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: scaleway-cloud-controller-manager
-          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.4
+          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.6
           imagePullPolicy: Always
           args:
             - --cloud-provider=scaleway

--- a/examples/k8s-scaleway-ccm-latest.yml
+++ b/examples/k8s-scaleway-ccm-latest.yml
@@ -32,7 +32,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: scaleway-cloud-controller-manager
-          image: scaleway/scaleway-cloud-controller-manager:latest
+          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.0
           imagePullPolicy: Always
           args:
             - --cloud-provider=scaleway

--- a/examples/k8s-scaleway-ccm-latest.yml
+++ b/examples/k8s-scaleway-ccm-latest.yml
@@ -32,7 +32,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: scaleway-cloud-controller-manager
-          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.1
+          image: ghcr.io/kommodity-io/scaleway-cloud-controller-manager:v0.36.0-kommodity.3
           imagePullPolicy: Always
           args:
             - --cloud-provider=scaleway

--- a/scaleway/cloud.go
+++ b/scaleway/cloud.go
@@ -53,6 +53,11 @@ const (
 	loadBalancerDefaultTypeEnv = "LB_DEFAULT_TYPE"
 
 	privateNetworkID = "PN_ID"
+
+	// enableLBPNNameSelectorEnv enables the selector-style annotation for LB to VPC/PN association.
+	// When set to "true", the pn-names annotation and IPAM-based node IP resolution are enabled.
+	// This feature is gated because it can cause issues on the Scaleway backend at scale.
+	enableLBPNNameSelectorEnv = "SCW_ENABLE_LB_PN_NAME_SELECTOR"
 )
 
 type cloud struct {

--- a/scaleway/errors.go
+++ b/scaleway/errors.go
@@ -19,13 +19,17 @@ package scaleway
 import "errors"
 
 var (
-	BadProviderID          = errors.New("provider ID wrong format: format should be scaleway://product/region/0788e6f4-55b0-42e2-936f-d0c5ecd49a13")
-	InstanceDuplicated     = errors.New("duplicated instance results")
-	IPAddressNotFound      = errors.New("ip address not found")
-	IPAddressInUse         = errors.New("ip address already in use")
-	LoadBalancerNotFound   = errors.New("loadbalancer not found")
-	LoadBalancerDuplicated = errors.New("loadbalancer duplicated")
-	LoadBalancerNotReady   = errors.New("loadbalancer is not ready")
+	BadProviderID            = errors.New("provider ID wrong format: format should be scaleway://product/region/0788e6f4-55b0-42e2-936f-d0c5ecd49a13")
+	InstanceDuplicated       = errors.New("duplicated instance results")
+	IPAddressNotFound        = errors.New("ip address not found")
+	IPAddressInUse           = errors.New("ip address already in use")
+	LoadBalancerNotFound     = errors.New("loadbalancer not found")
+	LoadBalancerDuplicated   = errors.New("loadbalancer duplicated")
+	LoadBalancerNotReady     = errors.New("loadbalancer is not ready")
+	PrivateNetworkNotFound   = errors.New("private network not found")
+	PrivateNetworkDuplicated = errors.New("multiple private networks found with same name")
+	VPCNotFound              = errors.New("VPC not found")
+	VPCDuplicated            = errors.New("multiple VPCs found with same name")
 
 	errLoadBalancerInvalidAnnotation     = errors.New("load balancer invalid annotation")
 	errLoadBalancerInvalidLoadBalancerID = errors.New("load balancer invalid loadbalancer-id annotation")

--- a/scaleway/loadbalancers.go
+++ b/scaleway/loadbalancers.go
@@ -41,6 +41,12 @@ import (
 
 const MaxEntriesPerACL = 60
 
+// lbPNNameSelectorEnabled returns true if the PN name selector feature is enabled
+// via the SCW_ENABLE_LB_PN_NAME_SELECTOR environment variable.
+func lbPNNameSelectorEnabled() bool {
+	return strings.EqualFold(os.Getenv(enableLBPNNameSelectorEnv), "true")
+}
+
 type loadbalancers struct {
 	api           LoadBalancerAPI
 	instance      LBInstanceAPI
@@ -163,7 +169,7 @@ func (l *loadbalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 		return nil, fmt.Errorf("invalid value for annotation %s: expected boolean", serviceAnnotationLoadBalancerPrivate)
 	}
 
-	if lbPrivate && l.pnID == "" && len(getPrivateNetworkIDs(service)) == 0 && len(getPrivateNetworkNames(service)) == 0 {
+	if lbPrivate && l.pnID == "" && len(getPrivateNetworkIDs(service)) == 0 && (lbPNNameSelectorEnabled() && len(getPrivateNetworkNames(service)) == 0) {
 		return nil, fmt.Errorf("scaleway-cloud-controller-manager cannot create private load balancers without a private network")
 	}
 
@@ -621,9 +627,13 @@ func (l *loadbalancers) updateLoadBalancer(ctx context.Context, loadbalancer *sc
 	}
 
 	// Discover the project ID from the cluster nodes for accurate VPC/PN lookup
-	nodeProjectID, err := l.getProjectIDFromNodes(nodes, region)
-	if err != nil {
-		klog.V(3).Infof("could not determine project ID from nodes: %v, falling back to default", err)
+	// (only needed when the PN name selector feature is enabled)
+	var nodeProjectID string
+	if lbPNNameSelectorEnabled() {
+		nodeProjectID, err = l.getProjectIDFromNodes(nodes, region)
+		if err != nil {
+			klog.V(3).Infof("could not determine project ID from nodes: %v, falling back to default", err)
+		}
 	}
 
 	configuredPNIDs, err := l.attachPrivateNetworks(loadbalancer, service, lbExternallyManaged, region, nodeProjectID)
@@ -632,7 +642,7 @@ func (l *loadbalancers) updateLoadBalancer(ctx context.Context, loadbalancer *sc
 	}
 
 	var targetIPs []string
-	if len(configuredPNIDs) > 0 {
+	if lbPNNameSelectorEnabled() && len(configuredPNIDs) > 0 {
 		// Use precise IPAM-based lookup to find node IPs on the configured private networks
 		targetIPs, err = l.getNodeIPsForPrivateNetworks(nodes, configuredPNIDs, region)
 		if err != nil {
@@ -868,8 +878,8 @@ func (l *loadbalancers) attachPrivateNetworks(loadbalancer *scwlb.LB, service *v
 			for _, pnID := range explicitIDs {
 				pnIDs[pnID] = false
 			}
-		} else {
-			// Priority 2: Names annotation - resolve to IDs
+		} else if lbPNNameSelectorEnabled() {
+			// Priority 2: Names annotation - resolve to IDs (requires SCW_ENABLE_LB_PN_NAME_SELECTOR=true)
 			pnNames := getPrivateNetworkNames(service)
 			if len(pnNames) > 0 {
 				resolvedIDs, err := l.resolvePrivateNetworkNames(pnNames, region, projectID)

--- a/scaleway/loadbalancers.go
+++ b/scaleway/loadbalancers.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
+	scwinstance "github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	scwipam "github.com/scaleway/scaleway-sdk-go/api/ipam/v1"
 	scwlb "github.com/scaleway/scaleway-sdk-go/api/lb/v1"
 	scwvpc "github.com/scaleway/scaleway-sdk-go/api/vpc/v2"
@@ -42,6 +43,7 @@ const MaxEntriesPerACL = 60
 
 type loadbalancers struct {
 	api           LoadBalancerAPI
+	instance      LBInstanceAPI
 	ipam          IPAMAPI
 	vpc           VPCAPI
 	client        *client // for patcher
@@ -49,8 +51,14 @@ type loadbalancers struct {
 	pnID          string
 }
 
+type LBInstanceAPI interface {
+	GetServer(req *scwinstance.GetServerRequest, opts ...scw.RequestOption) (*scwinstance.GetServerResponse, error)
+}
+
 type VPCAPI interface {
 	GetPrivateNetwork(req *scwvpc.GetPrivateNetworkRequest, opts ...scw.RequestOption) (*scwvpc.PrivateNetwork, error)
+	ListPrivateNetworks(req *scwvpc.ListPrivateNetworksRequest, opts ...scw.RequestOption) (*scwvpc.ListPrivateNetworksResponse, error)
+	ListVPCs(req *scwvpc.ListVPCsRequest, opts ...scw.RequestOption) (*scwvpc.ListVPCsResponse, error)
 }
 
 type LoadBalancerAPI interface {
@@ -88,6 +96,7 @@ func newLoadbalancers(client *client, defaultLBType, pnID string) *loadbalancers
 	}
 	return &loadbalancers{
 		api:           scwlb.NewZonedAPI(client.scaleway),
+		instance:      scwinstance.NewAPI(client.scaleway),
 		ipam:          scwipam.NewAPI(client.scaleway),
 		vpc:           scwvpc.NewAPI(client.scaleway),
 		client:        client,
@@ -154,7 +163,7 @@ func (l *loadbalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 		return nil, fmt.Errorf("invalid value for annotation %s: expected boolean", serviceAnnotationLoadBalancerPrivate)
 	}
 
-	if lbPrivate && l.pnID == "" {
+	if lbPrivate && l.pnID == "" && len(getPrivateNetworkIDs(service)) == 0 && len(getPrivateNetworkNames(service)) == 0 {
 		return nil, fmt.Errorf("scaleway-cloud-controller-manager cannot create private load balancers without a private network")
 	}
 
@@ -564,10 +573,10 @@ func (l *loadbalancers) annotateAndPatch(service *v1.Service, loadbalancer *scwl
 	service = service.DeepCopy()
 	patcher := NewServicePatcher(l.client.kubernetes, service)
 
-	if service.ObjectMeta.Annotations == nil {
-		service.ObjectMeta.Annotations = map[string]string{}
+	if service.Annotations == nil {
+		service.Annotations = map[string]string{}
 	}
-	service.ObjectMeta.Annotations[serviceAnnotationLoadBalancerID] = loadbalancer.Zone.String() + "/" + loadbalancer.ID
+	service.Annotations[serviceAnnotationLoadBalancerID] = loadbalancer.Zone.String() + "/" + loadbalancer.ID
 
 	return patcher.Patch()
 }
@@ -577,8 +586,8 @@ func (l *loadbalancers) unannotateAndPatch(service *v1.Service) error {
 	service = service.DeepCopy()
 	patcher := NewServicePatcher(l.client.kubernetes, service)
 
-	if service.ObjectMeta.Annotations != nil {
-		delete(service.ObjectMeta.Annotations, serviceAnnotationLoadBalancerID)
+	if service.Annotations != nil {
+		delete(service.Annotations, serviceAnnotationLoadBalancerID)
 	}
 
 	return patcher.Patch()
@@ -587,7 +596,7 @@ func (l *loadbalancers) unannotateAndPatch(service *v1.Service) error {
 // updateLoadBalancer updates the loadbalancer's resources
 func (l *loadbalancers) updateLoadBalancer(ctx context.Context, loadbalancer *scwlb.LB, service *v1.Service, nodes []*v1.Node) error {
 	// Skip update if the service is being deleted
-	if service.ObjectMeta.DeletionTimestamp != nil {
+	if service.DeletionTimestamp != nil {
 		klog.V(3).Infof("skipping loadbalancer update for service %s/%s: service is being deleted", service.Namespace, service.Name)
 		return nil
 	}
@@ -605,12 +614,33 @@ func (l *loadbalancers) updateLoadBalancer(ctx context.Context, loadbalancer *sc
 		return err
 	}
 
-	if err := l.attachPrivateNetworks(loadbalancer, service, lbExternallyManaged); err != nil {
+	// Get region for PN operations
+	region, err := loadbalancer.Zone.Region()
+	if err != nil {
+		return fmt.Errorf("unable to get region from zone %s: %v", loadbalancer.Zone, err)
+	}
+
+	// Discover the project ID from the cluster nodes for accurate VPC/PN lookup
+	nodeProjectID, err := l.getProjectIDFromNodes(nodes, region)
+	if err != nil {
+		klog.V(3).Infof("could not determine project ID from nodes: %v, falling back to default", err)
+	}
+
+	configuredPNIDs, err := l.attachPrivateNetworks(loadbalancer, service, lbExternallyManaged, region, nodeProjectID)
+	if err != nil {
 		return fmt.Errorf("failed to attach private networks: %w", err)
 	}
 
 	var targetIPs []string
-	if useInternalIPs {
+	if len(configuredPNIDs) > 0 {
+		// Use precise IPAM-based lookup to find node IPs on the configured private networks
+		targetIPs, err = l.getNodeIPsForPrivateNetworks(nodes, configuredPNIDs, region)
+		if err != nil {
+			klog.Warningf("failed to get node IPs for private networks, falling back to internal IPs: %v", err)
+			targetIPs = extractNodesInternalIps(nodes)
+		}
+		klog.V(3).Infof("using private network nodes ips: %s on loadbalancer %s", strings.Join(targetIPs, ","), loadbalancer.ID)
+	} else if useInternalIPs {
 		targetIPs = extractNodesInternalIps(nodes)
 		klog.V(3).Infof("using internal nodes ips: %s on loadbalancer %s", strings.Join(targetIPs, ","), loadbalancer.ID)
 	} else {
@@ -823,23 +853,44 @@ func (l *loadbalancers) updateLoadBalancer(ctx context.Context, loadbalancer *sc
 	return nil
 }
 
-func (l *loadbalancers) attachPrivateNetworks(loadbalancer *scwlb.LB, service *v1.Service, lbExternallyManaged bool) error {
-	if l.pnID == "" {
-		return nil
-	}
-
+// attachPrivateNetworks attaches the specified private networks to the load balancer.
+// It returns the list of private network IDs that were configured (for use in node IP lookup).
+// The projectID parameter is used to scope VPC/PN lookups to the correct project (derived from cluster nodes).
+func (l *loadbalancers) attachPrivateNetworks(loadbalancer *scwlb.LB, service *v1.Service, lbExternallyManaged bool, region scw.Region, projectID string) ([]string, error) {
 	// maps pnID => attached
 	pnIDs := make(map[string]bool)
 
 	// Fetch user-specified PrivateNetworkIDs unless LB is externally managed.
 	if !lbExternallyManaged {
-		for _, pnID := range getPrivateNetworkIDs(service) {
-			pnIDs[pnID] = false
+		// Priority 1: Explicit IDs annotation
+		explicitIDs := getPrivateNetworkIDs(service)
+		if len(explicitIDs) > 0 {
+			for _, pnID := range explicitIDs {
+				pnIDs[pnID] = false
+			}
+		} else {
+			// Priority 2: Names annotation - resolve to IDs
+			pnNames := getPrivateNetworkNames(service)
+			if len(pnNames) > 0 {
+				resolvedIDs, err := l.resolvePrivateNetworkNames(pnNames, region, projectID)
+				if err != nil {
+					return nil, err
+				}
+				for _, pnID := range resolvedIDs {
+					pnIDs[pnID] = false
+				}
+			}
 		}
 	}
 
-	if len(pnIDs) == 0 {
+	// Priority 3: Environment variable PN_ID (existing fallback)
+	if len(pnIDs) == 0 && l.pnID != "" {
 		pnIDs[l.pnID] = false
+	}
+
+	// Nothing to do if no private networks are configured
+	if len(pnIDs) == 0 {
+		return nil, nil
 	}
 
 	respPN, err := l.api.ListLBPrivateNetworks(&scwlb.ZonedAPIListLBPrivateNetworksRequest{
@@ -847,7 +898,7 @@ func (l *loadbalancers) attachPrivateNetworks(loadbalancer *scwlb.LB, service *v
 		LBID: loadbalancer.ID,
 	})
 	if err != nil {
-		return fmt.Errorf("error listing private networks of load balancer %s: %v", loadbalancer.ID, err)
+		return nil, fmt.Errorf("error listing private networks of load balancer %s: %v", loadbalancer.ID, err)
 	}
 
 	for _, pNIC := range respPN.PrivateNetwork {
@@ -866,7 +917,7 @@ func (l *loadbalancers) attachPrivateNetworks(loadbalancer *scwlb.LB, service *v
 				PrivateNetworkID: pNIC.PrivateNetworkID,
 			})
 			if err != nil {
-				return fmt.Errorf("unable to detach unmatched private network %s from %s: %v", pNIC.PrivateNetworkID, loadbalancer.ID, err)
+				return nil, fmt.Errorf("unable to detach unmatched private network %s from %s: %v", pNIC.PrivateNetworkID, loadbalancer.ID, err)
 			}
 		}
 	}
@@ -884,11 +935,260 @@ func (l *loadbalancers) attachPrivateNetworks(loadbalancer *scwlb.LB, service *v
 			DHCPConfig:       &scwlb.PrivateNetworkDHCPConfig{},
 		})
 		if err != nil {
-			return fmt.Errorf("unable to attach private network %s on %s: %v", pnID, loadbalancer.ID, err)
+			return nil, fmt.Errorf("unable to attach private network %s on %s: %v", pnID, loadbalancer.ID, err)
 		}
 	}
 
-	return nil
+	// Return the list of configured PN IDs
+	result := make([]string, 0, len(pnIDs))
+	for pnID := range pnIDs {
+		result = append(result, pnID)
+	}
+	return result, nil
+}
+
+// getVPCByName looks up a VPC by name in the specified region.
+// The projectID parameter scopes the lookup to a specific project (derived from cluster nodes).
+// Returns an error if no VPC is found or if multiple VPCs have the same name.
+func (l *loadbalancers) getVPCByName(name string, region scw.Region, projectID string) (*scwvpc.VPC, error) {
+	req := &scwvpc.ListVPCsRequest{
+		Region: region,
+		Name:   &name,
+	}
+
+	// Scope to the provided project ID to avoid cross-project conflicts
+	if projectID != "" {
+		req.ProjectID = &projectID
+	}
+
+	resp, err := l.vpc.ListVPCs(req, scw.WithAllPages())
+	if err != nil {
+		return nil, fmt.Errorf("error listing VPCs: %v", err)
+	}
+
+	var found *scwvpc.VPC
+	for _, vpc := range resp.Vpcs {
+		if vpc.Name == name { // Exact match required (API filter is fuzzy)
+			if found != nil {
+				return nil, VPCDuplicated
+			}
+			found = vpc
+		}
+	}
+
+	if found == nil {
+		return nil, VPCNotFound
+	}
+	return found, nil
+}
+
+// getPrivateNetworkByName looks up a private network by name in the specified region.
+// The name must be in the format "vpc-name/pn-name" to avoid ambiguity.
+// The projectID parameter scopes the VPC lookup to a specific project (derived from cluster nodes).
+// Returns an error if the format is invalid, no network is found, or if multiple networks have the same name.
+func (l *loadbalancers) getPrivateNetworkByName(name string, region scw.Region, projectID string) (*scwvpc.PrivateNetwork, error) {
+	// Require vpc-name/pn-name format
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid private network name format %q: must be in 'vpc-name/pn-name' format", name)
+	}
+
+	vpcName := strings.TrimSpace(parts[0])
+	pnName := strings.TrimSpace(parts[1])
+
+	if vpcName == "" || pnName == "" {
+		return nil, fmt.Errorf("invalid private network name format %q: both vpc-name and pn-name are required", name)
+	}
+
+	vpc, err := l.getVPCByName(vpcName, region, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve VPC %q: %w", vpcName, err)
+	}
+
+	req := &scwvpc.ListPrivateNetworksRequest{
+		Region: region,
+		Name:   &pnName,
+		VpcID:  &vpc.ID,
+	}
+
+	resp, err := l.vpc.ListPrivateNetworks(req, scw.WithAllPages())
+	if err != nil {
+		return nil, fmt.Errorf("error listing private networks: %v", err)
+	}
+
+	var found *scwvpc.PrivateNetwork
+	for _, pn := range resp.PrivateNetworks {
+		if pn.Name == pnName { // Exact match required (API filter is fuzzy)
+			if found != nil {
+				return nil, PrivateNetworkDuplicated
+			}
+			found = pn
+		}
+	}
+
+	if found == nil {
+		return nil, PrivateNetworkNotFound
+	}
+	return found, nil
+}
+
+// resolvePrivateNetworkNames converts private network names to IDs.
+// The projectID parameter scopes VPC lookups to a specific project (derived from cluster nodes).
+func (l *loadbalancers) resolvePrivateNetworkNames(names []string, region scw.Region, projectID string) ([]string, error) {
+	ids := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		pn, err := l.getPrivateNetworkByName(name, region, projectID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve private network name %q: %w", name, err)
+		}
+		ids = append(ids, pn.ID)
+	}
+	return ids, nil
+}
+
+// getNodeIPsForPrivateNetworks returns the private network IPs for nodes that are connected
+// to any of the specified private networks. This queries the Scaleway Instance API for each
+// node to find which private NICs are connected to the target PNs, then queries IPAM for their IPs.
+func (l *loadbalancers) getNodeIPsForPrivateNetworks(nodes []*v1.Node, pnIDs []string, region scw.Region) ([]string, error) {
+	if len(nodes) == 0 || len(pnIDs) == 0 {
+		return nil, nil
+	}
+
+	// Create a set of target PN IDs for fast lookup
+	targetPNs := make(map[string]bool)
+	for _, pnID := range pnIDs {
+		targetPNs[pnID] = true
+	}
+
+	var ips []string
+	for _, node := range nodes {
+		// Extract instance info from provider ID (format: scaleway://instance/<zone>/<instance-id>)
+		providerID := node.Spec.ProviderID
+		if providerID == "" {
+			klog.V(4).Infof("skipping node %s: no provider ID", node.Name)
+			continue
+		}
+
+		product, zoneStr, instanceID, err := ServerInfoFromProviderID(providerID)
+		if err != nil {
+			klog.V(4).Infof("skipping node %s: failed to parse provider ID %q: %v", node.Name, providerID, err)
+			continue
+		}
+
+		// Skip non-instance nodes (e.g., baremetal)
+		if product != InstanceTypeInstance {
+			klog.V(4).Infof("skipping node %s: not an instance (product=%s)", node.Name, product)
+			continue
+		}
+
+		zone := scw.Zone(zoneStr)
+
+		// Get server details from Instance API
+		serverResp, err := l.instance.GetServer(&scwinstance.GetServerRequest{
+			Zone:     zone,
+			ServerID: instanceID,
+		})
+		if err != nil {
+			klog.Warningf("failed to get server %s for node %s: %v", instanceID, node.Name, err)
+			continue
+		}
+
+		server := serverResp.Server
+		if server == nil || len(server.PrivateNics) == 0 {
+			klog.V(4).Infof("node %s has no private NICs", node.Name)
+			continue
+		}
+
+		// Find NICs connected to our target private networks
+		for _, nic := range server.PrivateNics {
+			if !targetPNs[nic.PrivateNetworkID] {
+				continue
+			}
+
+			// Query IPAM for this NIC's IP addresses
+			ipResp, err := l.ipam.ListIPs(&scwipam.ListIPsRequest{
+				Region:       region,
+				ResourceType: scwipam.ResourceTypeInstancePrivateNic,
+				ResourceID:   &nic.ID,
+				IsIPv6:       scw.BoolPtr(false),
+			})
+			if err != nil {
+				klog.Warningf("failed to get IPs for NIC %s on node %s: %v", nic.ID, node.Name, err)
+				continue
+			}
+
+			for _, ip := range ipResp.IPs {
+				ipAddr := ip.Address.IP.String()
+				klog.V(4).Infof("found IP %s for node %s on PN %s", ipAddr, node.Name, nic.PrivateNetworkID)
+				ips = append(ips, ipAddr)
+			}
+		}
+	}
+
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no node IPs found for configured private networks %v", pnIDs)
+	}
+
+	return ips, nil
+}
+
+// getProjectIDFromNodes extracts the project ID from cluster nodes by querying the Instance API.
+// This ensures VPC/PN lookups are scoped to the correct project where the nodes actually run,
+// rather than relying on environment variables that may point to a different project.
+// Returns the project ID if all nodes belong to the same project, or an error if nodes
+// are in different projects or if the project ID cannot be determined.
+func (l *loadbalancers) getProjectIDFromNodes(nodes []*v1.Node, region scw.Region) (string, error) {
+	if len(nodes) == 0 {
+		return "", fmt.Errorf("no nodes provided")
+	}
+
+	var projectID string
+	for _, node := range nodes {
+		providerID := node.Spec.ProviderID
+		if providerID == "" {
+			continue
+		}
+
+		product, zoneStr, instanceID, err := ServerInfoFromProviderID(providerID)
+		if err != nil {
+			klog.V(4).Infof("skipping node %s: failed to parse provider ID %q: %v", node.Name, providerID, err)
+			continue
+		}
+
+		// Skip non-instance nodes (e.g., baremetal)
+		if product != InstanceTypeInstance {
+			continue
+		}
+
+		zone := scw.Zone(zoneStr)
+
+		// Get server details from Instance API
+		serverResp, err := l.instance.GetServer(&scwinstance.GetServerRequest{
+			Zone:     zone,
+			ServerID: instanceID,
+		})
+		if err != nil {
+			klog.V(4).Infof("failed to get server %s for node %s: %v", instanceID, node.Name, err)
+			continue
+		}
+
+		nodeProject := serverResp.Server.Project
+		if projectID == "" {
+			projectID = nodeProject
+		} else if projectID != nodeProject {
+			return "", fmt.Errorf("nodes belong to different projects: %s and %s", projectID, nodeProject)
+		}
+	}
+
+	if projectID == "" {
+		return "", fmt.Errorf("could not determine project ID from any node")
+	}
+
+	return projectID, nil
 }
 
 // createPrivateServiceStatus creates a LoadBalancer status for services with private load balancers

--- a/scaleway/loadbalancers.go
+++ b/scaleway/loadbalancers.go
@@ -702,6 +702,13 @@ func (l *loadbalancers) updateLoadBalancer(ctx context.Context, loadbalancer *sc
 
 		// Update backend servers
 		if !stringArrayEqual(backend.Pool, targetIPs) {
+			// Safety: refuse to clear existing backends when no replacement IPs are found
+			if len(targetIPs) == 0 && len(backend.Pool) > 0 {
+				klog.Warningf("refusing to clear backend pool for backend %s on loadbalancer %s — keeping %d existing servers",
+					backend.ID, loadbalancer.ID, len(backend.Pool))
+				continue
+			}
+
 			klog.V(3).Infof("update server list for backend: %s port: %d loadbalancer: %s", backend.ID, port.NodePort, loadbalancer.ID)
 			if _, err := l.api.SetBackendServers(&scwlb.ZonedAPISetBackendServersRequest{
 				Zone:      loadbalancer.Zone,

--- a/scaleway/loadbalancers_annotations.go
+++ b/scaleway/loadbalancers_annotations.go
@@ -242,6 +242,15 @@ const (
 	//	- "<pn-id>,<pn-id>": will attach the two Private Networks to the LB.
 	serviceAnnotationPrivateNetworkIDs = "service.beta.kubernetes.io/scw-loadbalancer-pn-ids"
 
+	// serviceAnnotationPrivateNetworkNames is the annotation to configure the Private Networks
+	// by name instead of ID. The private network names will be resolved to IDs.
+	// If both pn-ids and pn-names are set, pn-ids takes precedence.
+	// This annotation is ignored when service.beta.kubernetes.io/scw-loadbalancer-externally-managed is enabled.
+	//
+	// The format must be "<vpc-name>/<pn-name>" to specify both the VPC and the private network.
+	// Multiple entries can be comma-separated: "<vpc-name>/<pn-name>,<vpc-name>/<pn-name>".
+	serviceAnnotationPrivateNetworkNames = "service.beta.kubernetes.io/scw-loadbalancer-pn-names"
+
 	// serviceAnnotationLoadBalancerHealthCheckFromService is the annotation to use healthCheckNodePort from the service
 	// The possible values are "false", "true" or "*" for all ports or a comma delimited list of the service port
 	// (for instance "80,443"). When enabled for a port, the health check will use the service's healthCheckNodePort
@@ -325,6 +334,15 @@ func getPrivateNetworkIDs(service *v1.Service) []string {
 	}
 
 	return strings.Split(pnIDs, ",")
+}
+
+func getPrivateNetworkNames(service *v1.Service) []string {
+	pnNames := service.Annotations[serviceAnnotationPrivateNetworkNames]
+	if pnNames == "" {
+		return nil
+	}
+
+	return strings.Split(pnNames, ",")
 }
 
 func getSendProxyV2(service *v1.Service, nodePort int32) (scwlb.ProxyProtocol, error) {

--- a/scaleway/loadbalancers_pn_test.go
+++ b/scaleway/loadbalancers_pn_test.go
@@ -1,0 +1,453 @@
+/*
+Copyright 2021 Scaleway
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaleway
+
+import (
+	"sort"
+	"testing"
+
+	scwlb "github.com/scaleway/scaleway-sdk-go/api/lb/v1"
+	scwvpc "github.com/scaleway/scaleway-sdk-go/api/vpc/v2"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// fakeLBAPI implements the subset of LoadBalancerAPI needed for attachPrivateNetworks tests.
+type fakeLBAPI struct {
+	privateNetworks []*scwlb.PrivateNetwork
+	attachCalls     []string // track attached PN IDs
+	detachCalls     []string // track detached PN IDs
+}
+
+func (f *fakeLBAPI) ListLBPrivateNetworks(req *scwlb.ZonedAPIListLBPrivateNetworksRequest, opts ...scw.RequestOption) (*scwlb.ListLBPrivateNetworksResponse, error) {
+	return &scwlb.ListLBPrivateNetworksResponse{
+		PrivateNetwork: f.privateNetworks,
+		TotalCount:     uint32(len(f.privateNetworks)),
+	}, nil
+}
+
+func (f *fakeLBAPI) AttachPrivateNetwork(req *scwlb.ZonedAPIAttachPrivateNetworkRequest, opts ...scw.RequestOption) (*scwlb.PrivateNetwork, error) {
+	f.attachCalls = append(f.attachCalls, req.PrivateNetworkID)
+	return &scwlb.PrivateNetwork{
+		PrivateNetworkID: req.PrivateNetworkID,
+		Status:           scwlb.PrivateNetworkStatusReady,
+	}, nil
+}
+
+func (f *fakeLBAPI) DetachPrivateNetwork(req *scwlb.ZonedAPIDetachPrivateNetworkRequest, opts ...scw.RequestOption) error {
+	f.detachCalls = append(f.detachCalls, req.PrivateNetworkID)
+	return nil
+}
+
+// Stubs for remaining LoadBalancerAPI interface methods (not used in these tests)
+func (f *fakeLBAPI) ListLBs(req *scwlb.ZonedAPIListLBsRequest, opts ...scw.RequestOption) (*scwlb.ListLBsResponse, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) GetLB(req *scwlb.ZonedAPIGetLBRequest, opts ...scw.RequestOption) (*scwlb.LB, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) CreateLB(req *scwlb.ZonedAPICreateLBRequest, opts ...scw.RequestOption) (*scwlb.LB, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) UpdateLB(req *scwlb.ZonedAPIUpdateLBRequest, opts ...scw.RequestOption) (*scwlb.LB, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) DeleteLB(req *scwlb.ZonedAPIDeleteLBRequest, opts ...scw.RequestOption) error {
+	return nil
+}
+func (f *fakeLBAPI) MigrateLB(req *scwlb.ZonedAPIMigrateLBRequest, opts ...scw.RequestOption) (*scwlb.LB, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) ListIPs(req *scwlb.ZonedAPIListIPsRequest, opts ...scw.RequestOption) (*scwlb.ListIPsResponse, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) ListBackends(req *scwlb.ZonedAPIListBackendsRequest, opts ...scw.RequestOption) (*scwlb.ListBackendsResponse, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) CreateBackend(req *scwlb.ZonedAPICreateBackendRequest, opts ...scw.RequestOption) (*scwlb.Backend, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) UpdateBackend(req *scwlb.ZonedAPIUpdateBackendRequest, opts ...scw.RequestOption) (*scwlb.Backend, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) DeleteBackend(req *scwlb.ZonedAPIDeleteBackendRequest, opts ...scw.RequestOption) error {
+	return nil
+}
+func (f *fakeLBAPI) SetBackendServers(req *scwlb.ZonedAPISetBackendServersRequest, opts ...scw.RequestOption) (*scwlb.Backend, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) UpdateHealthCheck(req *scwlb.ZonedAPIUpdateHealthCheckRequest, opts ...scw.RequestOption) (*scwlb.HealthCheck, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) ListFrontends(req *scwlb.ZonedAPIListFrontendsRequest, opts ...scw.RequestOption) (*scwlb.ListFrontendsResponse, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) CreateFrontend(req *scwlb.ZonedAPICreateFrontendRequest, opts ...scw.RequestOption) (*scwlb.Frontend, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) UpdateFrontend(req *scwlb.ZonedAPIUpdateFrontendRequest, opts ...scw.RequestOption) (*scwlb.Frontend, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) DeleteFrontend(req *scwlb.ZonedAPIDeleteFrontendRequest, opts ...scw.RequestOption) error {
+	return nil
+}
+func (f *fakeLBAPI) ListACLs(req *scwlb.ZonedAPIListACLsRequest, opts ...scw.RequestOption) (*scwlb.ListACLResponse, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) CreateACL(req *scwlb.ZonedAPICreateACLRequest, opts ...scw.RequestOption) (*scwlb.ACL, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) DeleteACL(req *scwlb.ZonedAPIDeleteACLRequest, opts ...scw.RequestOption) error {
+	return nil
+}
+func (f *fakeLBAPI) UpdateACL(req *scwlb.ZonedAPIUpdateACLRequest, opts ...scw.RequestOption) (*scwlb.ACL, error) {
+	return nil, nil
+}
+func (f *fakeLBAPI) SetACLs(req *scwlb.ZonedAPISetACLsRequest, opts ...scw.RequestOption) (*scwlb.SetACLsResponse, error) {
+	return nil, nil
+}
+
+// fakeVPCAPI implements VPCAPI for testing name resolution.
+type fakeVPCAPI struct {
+	vpcs            []*scwvpc.VPC
+	privateNetworks []*scwvpc.PrivateNetwork
+}
+
+func (f *fakeVPCAPI) GetPrivateNetwork(req *scwvpc.GetPrivateNetworkRequest, opts ...scw.RequestOption) (*scwvpc.PrivateNetwork, error) {
+	for _, pn := range f.privateNetworks {
+		if pn.ID == req.PrivateNetworkID {
+			return pn, nil
+		}
+	}
+	return nil, &scw.ResourceNotFoundError{}
+}
+
+func (f *fakeVPCAPI) ListPrivateNetworks(req *scwvpc.ListPrivateNetworksRequest, opts ...scw.RequestOption) (*scwvpc.ListPrivateNetworksResponse, error) {
+	var result []*scwvpc.PrivateNetwork
+	for _, pn := range f.privateNetworks {
+		if req.VpcID != nil && pn.VpcID != *req.VpcID {
+			continue
+		}
+		if req.Name != nil && pn.Name != *req.Name {
+			continue
+		}
+		result = append(result, pn)
+	}
+	return &scwvpc.ListPrivateNetworksResponse{
+		PrivateNetworks: result,
+		TotalCount:      uint32(len(result)),
+	}, nil
+}
+
+func (f *fakeVPCAPI) ListVPCs(req *scwvpc.ListVPCsRequest, opts ...scw.RequestOption) (*scwvpc.ListVPCsResponse, error) {
+	var result []*scwvpc.VPC
+	for _, vpc := range f.vpcs {
+		if req.Name != nil && vpc.Name != *req.Name {
+			continue
+		}
+		if req.ProjectID != nil && vpc.ProjectID != *req.ProjectID {
+			continue
+		}
+		result = append(result, vpc)
+	}
+	return &scwvpc.ListVPCsResponse{
+		Vpcs:       result,
+		TotalCount: uint32(len(result)),
+	}, nil
+}
+
+func newTestLB(lbAPI *fakeLBAPI, vpcAPI *fakeVPCAPI, pnID string) *loadbalancers {
+	return &loadbalancers{
+		api:  lbAPI,
+		vpc:  vpcAPI,
+		pnID: pnID,
+	}
+}
+
+func TestAttachPrivateNetworks(t *testing.T) {
+	testLB := &scwlb.LB{
+		ID:   "lb-1",
+		Zone: scw.ZoneFrPar2,
+	}
+
+	vpcAPI := &fakeVPCAPI{
+		vpcs: []*scwvpc.VPC{
+			{ID: "vpc-default", Name: "default", Region: scw.RegionFrPar, ProjectID: "proj-1"},
+			{ID: "vpc-other", Name: "other-vpc", Region: scw.RegionFrPar, ProjectID: "proj-1"},
+		},
+		privateNetworks: []*scwvpc.PrivateNetwork{
+			{ID: "pn-resolved-1", Name: "my-cluster", VpcID: "vpc-default"},
+			{ID: "pn-resolved-2", Name: "my-other-pn", VpcID: "vpc-other"},
+		},
+	}
+
+	tests := []struct {
+		name                string
+		service             *v1.Service
+		envPNID             string
+		existingPNs         []*scwlb.PrivateNetwork
+		lbExternallyManaged bool
+		wantConfiguredIDs   []string
+		wantAttachCalls     []string
+		wantDetachCalls     []string
+		wantErr             bool
+	}{
+		{
+			name: "Priority 1: pn-ids annotation attaches PN and returns IDs",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-ids": "pn-explicit-1",
+					},
+				},
+			},
+			existingPNs:       nil,
+			wantConfiguredIDs: []string{"pn-explicit-1"},
+			wantAttachCalls:   []string{"pn-explicit-1"},
+		},
+		{
+			name: "Priority 1: multiple pn-ids",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-ids": "pn-a,pn-b",
+					},
+				},
+			},
+			existingPNs:       nil,
+			wantConfiguredIDs: []string{"pn-a", "pn-b"},
+			wantAttachCalls:   []string{"pn-a", "pn-b"},
+		},
+		{
+			name: "Priority 1: pn-ids already attached skips attach call",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-ids": "pn-already-attached",
+					},
+				},
+			},
+			existingPNs: []*scwlb.PrivateNetwork{
+				{PrivateNetworkID: "pn-already-attached", Status: scwlb.PrivateNetworkStatusReady},
+			},
+			wantConfiguredIDs: []string{"pn-already-attached"},
+			wantAttachCalls:   nil, // no attach needed
+		},
+		{
+			name: "Priority 2: pn-names resolves and returns IDs",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "default/my-cluster",
+					},
+				},
+			},
+			existingPNs:       nil,
+			wantConfiguredIDs: []string{"pn-resolved-1"},
+			wantAttachCalls:   []string{"pn-resolved-1"},
+		},
+		{
+			name: "Priority 2: multiple pn-names across VPCs",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "default/my-cluster,other-vpc/my-other-pn",
+					},
+				},
+			},
+			existingPNs:       nil,
+			wantConfiguredIDs: []string{"pn-resolved-1", "pn-resolved-2"},
+			wantAttachCalls:   []string{"pn-resolved-1", "pn-resolved-2"},
+		},
+		{
+			name: "Priority 3: env var PN_ID used when no annotations",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			envPNID:           "pn-from-env",
+			existingPNs:       nil,
+			wantConfiguredIDs: []string{"pn-from-env"},
+			wantAttachCalls:   []string{"pn-from-env"},
+		},
+		{
+			name: "Priority: pn-ids takes precedence over pn-names",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-ids":   "pn-explicit",
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "default/my-cluster",
+					},
+				},
+			},
+			existingPNs:       nil,
+			wantConfiguredIDs: []string{"pn-explicit"},
+			wantAttachCalls:   []string{"pn-explicit"},
+		},
+		{
+			name: "Priority: pn-ids takes precedence over env var",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-ids": "pn-explicit",
+					},
+				},
+			},
+			envPNID:           "pn-from-env",
+			existingPNs:       nil,
+			wantConfiguredIDs: []string{"pn-explicit"},
+			wantAttachCalls:   []string{"pn-explicit"},
+		},
+		{
+			name: "Priority: pn-names takes precedence over env var",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "default/my-cluster",
+					},
+				},
+			},
+			envPNID:           "pn-from-env",
+			existingPNs:       nil,
+			wantConfiguredIDs: []string{"pn-resolved-1"},
+			wantAttachCalls:   []string{"pn-resolved-1"},
+		},
+		{
+			name: "No PN config returns nil",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			envPNID:           "",
+			existingPNs:       nil,
+			wantConfiguredIDs: nil,
+			wantAttachCalls:   nil,
+		},
+		{
+			name: "Detaches unmatched PNs when not externally managed",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-ids": "pn-wanted",
+					},
+				},
+			},
+			existingPNs: []*scwlb.PrivateNetwork{
+				{PrivateNetworkID: "pn-stale", Status: scwlb.PrivateNetworkStatusReady},
+			},
+			wantConfiguredIDs: []string{"pn-wanted"},
+			wantAttachCalls:   []string{"pn-wanted"},
+			wantDetachCalls:   []string{"pn-stale"},
+		},
+		{
+			name: "Externally managed: skips annotation-based PNs, uses env var",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-ids": "pn-ignored",
+					},
+				},
+			},
+			lbExternallyManaged: true,
+			envPNID:             "pn-from-env",
+			existingPNs:         nil,
+			wantConfiguredIDs:   []string{"pn-from-env"},
+			wantAttachCalls:     []string{"pn-from-env"},
+		},
+		{
+			name: "Externally managed: does not detach unmatched PNs",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			lbExternallyManaged: true,
+			envPNID:             "pn-from-env",
+			existingPNs: []*scwlb.PrivateNetwork{
+				{PrivateNetworkID: "pn-other", Status: scwlb.PrivateNetworkStatusReady},
+			},
+			wantConfiguredIDs: []string{"pn-from-env"},
+			wantAttachCalls:   []string{"pn-from-env"},
+			wantDetachCalls:   nil, // externally managed: no detach
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lbAPI := &fakeLBAPI{
+				privateNetworks: tt.existingPNs,
+			}
+			lb := newTestLB(lbAPI, vpcAPI, tt.envPNID)
+
+			gotIDs, err := lb.attachPrivateNetworks(testLB, tt.service, tt.lbExternallyManaged, scw.RegionFrPar, "proj-1")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("attachPrivateNetworks() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Sort for deterministic comparison (map iteration order is random)
+			sort.Strings(gotIDs)
+			sort.Strings(tt.wantConfiguredIDs)
+			if len(gotIDs) == 0 && len(tt.wantConfiguredIDs) == 0 {
+				// both empty/nil, ok
+			} else if len(gotIDs) != len(tt.wantConfiguredIDs) {
+				t.Errorf("attachPrivateNetworks() returned IDs = %v, want %v", gotIDs, tt.wantConfiguredIDs)
+			} else {
+				for i := range gotIDs {
+					if gotIDs[i] != tt.wantConfiguredIDs[i] {
+						t.Errorf("attachPrivateNetworks() returned IDs = %v, want %v", gotIDs, tt.wantConfiguredIDs)
+						break
+					}
+				}
+			}
+
+			// Verify attach calls
+			sort.Strings(lbAPI.attachCalls)
+			sort.Strings(tt.wantAttachCalls)
+			if len(lbAPI.attachCalls) == 0 && len(tt.wantAttachCalls) == 0 {
+				// both empty, ok
+			} else if len(lbAPI.attachCalls) != len(tt.wantAttachCalls) {
+				t.Errorf("attach calls = %v, want %v", lbAPI.attachCalls, tt.wantAttachCalls)
+			} else {
+				for i := range lbAPI.attachCalls {
+					if lbAPI.attachCalls[i] != tt.wantAttachCalls[i] {
+						t.Errorf("attach calls = %v, want %v", lbAPI.attachCalls, tt.wantAttachCalls)
+						break
+					}
+				}
+			}
+
+			// Verify detach calls
+			sort.Strings(lbAPI.detachCalls)
+			sort.Strings(tt.wantDetachCalls)
+			if len(lbAPI.detachCalls) == 0 && len(tt.wantDetachCalls) == 0 {
+				// both empty, ok
+			} else if len(lbAPI.detachCalls) != len(tt.wantDetachCalls) {
+				t.Errorf("detach calls = %v, want %v", lbAPI.detachCalls, tt.wantDetachCalls)
+			} else {
+				for i := range lbAPI.detachCalls {
+					if lbAPI.detachCalls[i] != tt.wantDetachCalls[i] {
+						t.Errorf("detach calls = %v, want %v", lbAPI.detachCalls, tt.wantDetachCalls)
+						break
+					}
+				}
+			}
+		})
+	}
+}

--- a/scaleway/loadbalancers_pn_test.go
+++ b/scaleway/loadbalancers_pn_test.go
@@ -27,6 +27,107 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestLBPNNameSelectorGate(t *testing.T) {
+	vpcAPI := &fakeVPCAPI{
+		vpcs: []*scwvpc.VPC{
+			{ID: "vpc-default", Name: "default", Region: scw.RegionFrPar, ProjectID: "proj-1"},
+		},
+		privateNetworks: []*scwvpc.PrivateNetwork{
+			{ID: "pn-resolved-1", Name: "my-cluster", VpcID: "vpc-default"},
+		},
+	}
+
+	testLB := &scwlb.LB{
+		ID:   "lb-1",
+		Zone: scw.ZoneFrPar2,
+	}
+
+	t.Run("pn-names ignored when gate is disabled", func(t *testing.T) {
+		// Do NOT set SCW_ENABLE_LB_PN_NAME_SELECTOR (gate off by default)
+		t.Setenv(enableLBPNNameSelectorEnv, "")
+
+		lbAPI := &fakeLBAPI{}
+		lb := newTestLB(lbAPI, vpcAPI, "pn-from-env")
+
+		service := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "default/my-cluster",
+				},
+			},
+		}
+
+		gotIDs, err := lb.attachPrivateNetworks(testLB, service, false, scw.RegionFrPar, "proj-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// pn-names should be ignored; should fall back to env var PN_ID
+		if len(gotIDs) != 1 || gotIDs[0] != "pn-from-env" {
+			t.Errorf("expected fallback to env var PN_ID [pn-from-env], got %v", gotIDs)
+		}
+		if len(lbAPI.attachCalls) != 1 || lbAPI.attachCalls[0] != "pn-from-env" {
+			t.Errorf("expected attach call for pn-from-env, got %v", lbAPI.attachCalls)
+		}
+	})
+
+	t.Run("pn-names used when gate is enabled", func(t *testing.T) {
+		t.Setenv(enableLBPNNameSelectorEnv, "true")
+
+		lbAPI := &fakeLBAPI{}
+		lb := newTestLB(lbAPI, vpcAPI, "pn-from-env")
+
+		service := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "default/my-cluster",
+				},
+			},
+		}
+
+		gotIDs, err := lb.attachPrivateNetworks(testLB, service, false, scw.RegionFrPar, "proj-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// pn-names should resolve, taking precedence over env var
+		if len(gotIDs) != 1 || gotIDs[0] != "pn-resolved-1" {
+			t.Errorf("expected resolved PN [pn-resolved-1], got %v", gotIDs)
+		}
+		if len(lbAPI.attachCalls) != 1 || lbAPI.attachCalls[0] != "pn-resolved-1" {
+			t.Errorf("expected attach call for pn-resolved-1, got %v", lbAPI.attachCalls)
+		}
+	})
+
+	t.Run("pn-names only with no env var returns nil when gate disabled", func(t *testing.T) {
+		t.Setenv(enableLBPNNameSelectorEnv, "")
+
+		lbAPI := &fakeLBAPI{}
+		lb := newTestLB(lbAPI, vpcAPI, "") // no env var PN_ID
+
+		service := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "default/my-cluster",
+				},
+			},
+		}
+
+		gotIDs, err := lb.attachPrivateNetworks(testLB, service, false, scw.RegionFrPar, "proj-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// pn-names ignored + no env var = no PNs configured
+		if gotIDs != nil {
+			t.Errorf("expected nil configured IDs when gate disabled and no env var, got %v", gotIDs)
+		}
+		if len(lbAPI.attachCalls) != 0 {
+			t.Errorf("expected no attach calls, got %v", lbAPI.attachCalls)
+		}
+	})
+}
+
 // fakeLBAPI implements the subset of LoadBalancerAPI needed for attachPrivateNetworks tests.
 type fakeLBAPI struct {
 	privateNetworks []*scwlb.PrivateNetwork
@@ -391,6 +492,9 @@ func TestAttachPrivateNetworks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Enable the PN name selector feature for all tests in this suite
+			t.Setenv(enableLBPNNameSelectorEnv, "true")
+
 			lbAPI := &fakeLBAPI{
 				privateNetworks: tt.existingPNs,
 			}

--- a/scaleway/loadbalancers_test.go
+++ b/scaleway/loadbalancers_test.go
@@ -1453,9 +1453,9 @@ func TestPtrUint32ToString(t *testing.T) {
 	}
 }
 func TestStrPtrEqual(t *testing.T) {
-	var str1 string = "test"
-	var otherStr1 string = "test"
-	var str2 string = "test2"
+	var str1 = "test"
+	var otherStr1 = "test"
+	var str2 = "test2"
 
 	matrix := []struct {
 		name string
@@ -2646,5 +2646,100 @@ func TestServiceToLB_UDPPortsIgnored(t *testing.T) {
 	}
 	if len(backends) != 1 {
 		t.Errorf("expected 1 backend, got %d", len(backends))
+	}
+}
+
+func TestGetPrivateNetworkNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		service *v1.Service
+		want    []string
+	}{
+		{
+			name: "no annotation",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "empty annotation",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "single vpc/pn entry",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "default/my-private-network",
+					},
+				},
+			},
+			want: []string{"default/my-private-network"},
+		},
+		{
+			name: "multiple vpc/pn entries",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "vpc-1/network-1,vpc-2/network-2,vpc-3/network-3",
+					},
+				},
+			},
+			want: []string{"vpc-1/network-1", "vpc-2/network-2", "vpc-3/network-3"},
+		},
+		{
+			name: "same vpc multiple networks",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "default/network-1,default/network-2",
+					},
+				},
+			},
+			want: []string{"default/network-1", "default/network-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getPrivateNetworkNames(tt.service)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getPrivateNetworkNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrivateNetworkIDsAnnotationTakesPrecedence(t *testing.T) {
+	// Test that pn-ids takes precedence over pn-names
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"service.beta.kubernetes.io/scw-loadbalancer-pn-ids":   "explicit-id-1,explicit-id-2",
+				"service.beta.kubernetes.io/scw-loadbalancer-pn-names": "name-1,name-2",
+			},
+		},
+	}
+
+	// pn-ids should return the explicit IDs
+	pnIDs := getPrivateNetworkIDs(service)
+	if len(pnIDs) != 2 || pnIDs[0] != "explicit-id-1" || pnIDs[1] != "explicit-id-2" {
+		t.Errorf("getPrivateNetworkIDs() = %v, want [explicit-id-1, explicit-id-2]", pnIDs)
+	}
+
+	// pn-names should still return names (but they won't be used if pn-ids is set)
+	pnNames := getPrivateNetworkNames(service)
+	if len(pnNames) != 2 || pnNames[0] != "name-1" || pnNames[1] != "name-2" {
+		t.Errorf("getPrivateNetworkNames() = %v, want [name-1, name-2]", pnNames)
 	}
 }


### PR DESCRIPTION
# Changes

- Adds support for a new annotation on Kubernetes services of type `LoadBalancer` named `service.beta.kubernetes.io/scw-loadbalancer-pn-names` in order to make GitOps easier by using pairs of `<VPC-name>/<PN-name>[,<...>/<...>]` as opposed to using `service.beta.kubernetes.io/scw-loadbalancer-pn-ids` that might change over time or adds a second step of configuration when deploying clusters
- Adds an environment variable gate (must set `SCW_ENABLE_LB_PN_NAME_SELECTOR=true`) to enable this feature so that it's an explicit opt-in feature

## Backwards compatiblity

Since there are already settings for getting the LB associated with a specific PN, we put the priority as such for acting on specific configuration if multiple are present:
`pn-ids` (annotation) > `pn-names` (annotation) > `PN_ID` env var.

## Key details

- **Name format**: `vpc-name/pn-name` required to avoid ambiguity across VPCs. Comma-separated for multiple networks.
- **Project scoping**: VPC/PN lookups scoped to the project where cluster nodes run (derived via Instance API), preventing cross-project name collisions.
- **Backend IP resolution**: Uses precise IPAM-based lookup via `getNodeIPsForPrivateNetworks` — queries each node's private NICs and resolves IPs through IPAM rather than relying on `extractNodesInternalIps` which may return IPs from unrelated private networks.
- **Private LB guard**: Updated to accept `pn-names` (and `pn-ids`) so private LBs no longer require the `PN_ID` env var when annotations are set.
- **Error handling**: Clear errors for missing/duplicate VPCs and private networks.

This has been tested to work in a self-managed Kubernetes cluster running on Scaleway VMs.